### PR TITLE
change to return a pointer of xxError struct

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 2.0.0-dev (unreleased)
+
+#### Breaking Changes
+
+- Change to return a pointer of xxError struct
+
 ## 1.0.1 (2015/07/12)
 
 - Fix validating authoritative engine

--- a/errors.go
+++ b/errors.go
@@ -13,7 +13,7 @@ type ArgumentError struct {
 	Message string      // Error message
 }
 
-func (e ArgumentError) Error() string {
+func (e *ArgumentError) Error() string {
 	return fmt.Sprintf("%s, value `%v`", e.Message, e.Value)
 }
 
@@ -24,7 +24,7 @@ type ResponseError struct {
 	Detail  string // Detail of the error for debugging
 }
 
-func (e ResponseError) Error() string {
+func (e *ResponseError) Error() string {
 	if e.Cause == nil {
 		return e.Message
 	} else {
@@ -33,5 +33,5 @@ func (e ResponseError) Error() string {
 }
 
 type notInTimeWindowError struct {
-	ResponseError
+	*ResponseError
 }

--- a/message.go
+++ b/message.go
@@ -369,7 +369,7 @@ func (mp *messageProcessingV1) PrepareDataElements(
 	recvMsg := newMessage(snmp.args.Version, pdu)
 	_, err = recvMsg.Unmarshal(b)
 	if err != nil {
-		return nil, ResponseError{
+		return nil, &ResponseError{
 			Cause:   err,
 			Message: "Failed to Unmarshal message",
 			Detail:  fmt.Sprintf("message Bytes - [%s]", toHexStr(b, " ")),
@@ -377,7 +377,7 @@ func (mp *messageProcessingV1) PrepareDataElements(
 	}
 
 	if sendMsg.Version() != recvMsg.Version() {
-		return nil, ResponseError{
+		return nil, &ResponseError{
 			Message: fmt.Sprintf(
 				"SNMPVersion mismatch - expected [%v], actual [%v]",
 				sendMsg.Version(), recvMsg.Version()),
@@ -391,13 +391,13 @@ func (mp *messageProcessingV1) PrepareDataElements(
 	}
 
 	if recvMsg.Pdu().PduType() != GetResponse {
-		return nil, ResponseError{
+		return nil, &ResponseError{
 			Message: fmt.Sprintf("Illegal PduType - expected [%s], actual [%v]",
 				GetResponse, recvMsg.Pdu().PduType()),
 		}
 	}
 	if sendMsg.Pdu().RequestId() != recvMsg.Pdu().RequestId() {
-		return nil, ResponseError{
+		return nil, &ResponseError{
 			Message: fmt.Sprintf("RequestId mismatch - expected [%d], actual [%d]",
 				sendMsg.Pdu().RequestId(), recvMsg.Pdu().RequestId()),
 			Detail: fmt.Sprintf("%s vs %s", sendMsg, recvMsg),
@@ -443,7 +443,7 @@ func (mp *messageProcessingV3) PrepareDataElements(
 	recvMsg := newMessage(snmp.args.Version, pdu)
 	_, err = recvMsg.Unmarshal(b)
 	if err != nil {
-		return nil, ResponseError{
+		return nil, &ResponseError{
 			Cause:   err,
 			Message: "Failed to Unmarshal message",
 			Detail:  fmt.Sprintf("message Bytes - [%s]", toHexStr(b, " ")),
@@ -453,21 +453,21 @@ func (mp *messageProcessingV3) PrepareDataElements(
 	sm := sendMsg.(*messageV3)
 	rm := recvMsg.(*messageV3)
 	if sm.Version() != rm.Version() {
-		return nil, ResponseError{
+		return nil, &ResponseError{
 			Message: fmt.Sprintf(
 				"SNMPVersion mismatch - expected [%v], actual [%v]", sm.Version(), rm.Version()),
 			Detail: fmt.Sprintf("%s vs %s", sm, rm),
 		}
 	}
 	if sm.MessageId != rm.MessageId {
-		return nil, ResponseError{
+		return nil, &ResponseError{
 			Message: fmt.Sprintf(
 				"MessageId mismatch - expected [%d], actual [%d]", sm.MessageId, rm.MessageId),
 			Detail: fmt.Sprintf("%s vs %s", sm, rm),
 		}
 	}
 	if rm.SecurityModel != securityUsm {
-		return nil, ResponseError{
+		return nil, &ResponseError{
 			Message: fmt.Sprintf("Unknown SecurityModel, value [%d]", rm.SecurityModel),
 		}
 	}
@@ -480,7 +480,7 @@ func (mp *messageProcessingV3) PrepareDataElements(
 	switch t := rm.Pdu().PduType(); t {
 	case GetResponse:
 		if sm.Pdu().RequestId() != rm.Pdu().RequestId() {
-			return nil, ResponseError{
+			return nil, &ResponseError{
 				Message: fmt.Sprintf("RequestId mismatch - expected [%d], actual [%d]",
 					sm.Pdu().RequestId(), rm.Pdu().RequestId()),
 				Detail: fmt.Sprintf("%s vs %s", sm, rm),
@@ -492,7 +492,7 @@ func (mp *messageProcessingV3) PrepareDataElements(
 		}
 		fallthrough
 	default:
-		return nil, ResponseError{
+		return nil, &ResponseError{
 			Message: fmt.Sprintf("Illegal PduType - expected [%s], actual [%v]", GetResponse, t),
 		}
 	}

--- a/util.go
+++ b/util.go
@@ -54,13 +54,13 @@ func genMessageId() (id int) {
 func retry(retries int, f func() error) (err error) {
 	for i := 0; i <= retries; i++ {
 		err = f()
-		switch err.(type) {
+		switch e := err.(type) {
 		case net.Error:
-			if err.(net.Error).Timeout() {
+			if e.Timeout() {
 				continue
 			}
-		case notInTimeWindowError:
-			err = err.(notInTimeWindowError).ResponseError
+		case *notInTimeWindowError:
+			err = e.ResponseError
 			continue
 		}
 		return
@@ -79,7 +79,7 @@ func confirmedType(t PduType) bool {
 func engineIdToBytes(engineId string) ([]byte, error) {
 	b, err := hex.DecodeString(engineId)
 	if l := len(b); err != nil || (l < 5 || l > 32) {
-		return nil, ArgumentError{
+		return nil, &ArgumentError{
 			Value:   engineId,
 			Message: "EngineId must be a hexadecimal string and length is range 5..32",
 		}

--- a/variables.go
+++ b/variables.go
@@ -200,7 +200,7 @@ func NewOid(s string) (oid *Oid, err error) {
 
 	// RFC2578 Section 3.5
 	if len(subids) > 128 {
-		return nil, ArgumentError{
+		return nil, &ArgumentError{
 			Value:   s,
 			Message: "The sub-identifiers in an OID is up to 128",
 		}
@@ -210,7 +210,7 @@ func NewOid(s string) (oid *Oid, err error) {
 	for i, v := range subids {
 		o[i], err = strconv.Atoi(v)
 		if err != nil || o[i] < 0 || o[i] > math.MaxUint32 {
-			return nil, ArgumentError{
+			return nil, &ArgumentError{
 				Value:   s,
 				Message: fmt.Sprintf("The sub-identifiers is range %d..%d", 0, math.MaxUint32),
 			}
@@ -218,7 +218,7 @@ func NewOid(s string) (oid *Oid, err error) {
 	}
 
 	if len(o) > 0 && o[0] > 2 {
-		return nil, ArgumentError{
+		return nil, &ArgumentError{
 			Value:   s,
 			Message: "The first sub-identifier is range 0..2",
 		}
@@ -226,14 +226,14 @@ func NewOid(s string) (oid *Oid, err error) {
 
 	// ISO/IEC 8825 Section 8.19.4
 	if len(o) < 2 {
-		return nil, ArgumentError{
+		return nil, &ArgumentError{
 			Value:   s,
 			Message: "The first and second sub-identifier is required",
 		}
 	}
 
 	if o[0] < 2 && o[1] >= 40 {
-		return nil, ArgumentError{
+		return nil, &ArgumentError{
 			Value:   s,
 			Message: "The second sub-identifier is range 0..39",
 		}


### PR DESCRIPTION
How to migrate your code

```diff
 import "github.com/k-sone/snmpgo"
 ...
     pdu, err := snmp.GetBulkWalk(oids, 0, 10)
     switch e := err.(type) {
-    case snmpgo.ArgumentError:
+    case *snmpgo.ArgumentError:
         ...    // handle ArgumentError
-    case snmpgo.ResponseError:
+    case *snmpgo.ResponseError:
         ...    // handle ResponseError
     }
 ...
```