### PR TITLE
trap: receive trap events

### DIFF
--- a/server.go
+++ b/server.go
@@ -18,12 +18,10 @@ type TrapListener interface {
 	OnTRAP(trap *TrapRequest)
 }
 
-/**
- *  TrapRequest is representing trap request that is send from the network element.
- */
+// TrapRequest is representing trap request that is send from the network element.
 type TrapRequest struct {
-	// The received Trap message
-	Message message
+	// The received PDU
+	Pdu Pdu
 
 	// Error is an optional field used to indicate
 	// errors which may occur during the decoding
@@ -117,7 +115,7 @@ func (s *Server) handle(buf []byte) {
 		_, err = recvMsg.Pdu().Unmarshal(recvMsg.PduBytes())
 	}
 
-	s.Listener.OnTRAP(&TrapRequest{recvMsg, err})
+	s.Listener.OnTRAP(&TrapRequest{recvMsg.Pdu(), err})
 }
 
 func (s *Server) logf(format string, args ...interface{}) {

--- a/server.go
+++ b/server.go
@@ -1,0 +1,129 @@
+package snmpgo
+
+import (
+	"log"
+	"net"
+	"runtime"
+	"time"
+)
+
+const (
+	maxTrapSize = 2 << 11 // 2048 bytes
+)
+
+// TrapListener defines method that need to be implemented by Trap listeners.
+// If OnTRAP panics, the server (caller of OnTRAP) assumes that affect of the panic
+// is temporary and recovers by the panic and logs trace to the error log.
+type TrapListener interface {
+	OnTRAP(trap *TrapRequest)
+}
+
+/**
+ *  TrapRequest is representing trap request that is send from the network element.
+ */
+type TrapRequest struct {
+	// The received Trap message
+	Message message
+
+	// Error is an optional field used to indicate
+	// errors which may occur during the decoding
+	// of the received packet
+	Error error
+}
+
+// A Server defines parameters for running of TRAP daemon that listens for incoming
+// trap messages.
+type Server struct {
+	// Addr is the address in format "localhost:5000" on which server will listen
+	Addr string
+
+	// Trap Listener
+	Listener TrapListener
+
+	// Error Logger which will be used for logging of default errors
+	ErrorLog *log.Logger
+}
+
+// Listen listens on UDP network address and then calls Serve with TrapListener to dispatch received TRAP messages to it.
+func (s *Server) Listen(address string, listener TrapListener) error {
+	s.Addr = address
+	addr, err := net.ResolveUDPAddr("udp4", s.Addr)
+	if err != nil {
+		return err
+	}
+
+	l, err := net.ListenUDP("udp4", addr)
+	if err != nil {
+		return err
+	}
+
+	s.Serve(l, listener)
+
+	return nil
+}
+
+func (s *Server) Serve(l net.Conn, listener TrapListener) {
+	defer l.Close()
+	s.Listener = listener
+
+	for {
+		buf := make([]byte, maxTrapSize)
+
+		l.SetDeadline(time.Now().Add(500 * time.Millisecond))
+
+		n, err := l.Read(buf)
+
+		if err != nil {
+			netErr, ok := err.(net.Error)
+			if ok && netErr.Timeout() {
+				continue
+			}
+
+			// Break when connection is closed
+			break
+		}
+
+		// Bigger messages are skipped for processing.
+		if n == maxTrapSize {
+			continue
+		}
+
+		go s.handle(buf[0:n])
+	}
+}
+
+// handle a newly received trap
+func (s *Server) handle(buf []byte) {
+	defer func() {
+		if err := recover(); err != nil {
+			const size = 64 << 10
+			logBuf := make([]byte, size)
+			logBuf = logBuf[:runtime.Stack(logBuf, false)]
+			s.logf("trap: panic while listening %v: %v\n%s", s.Addr, err, logBuf)
+
+		}
+	}()
+
+	if s.Listener == nil {
+		s.logf("trap: listener is not attached and trap information cannot be dispatched.")
+		return
+	}
+
+	//Decode received trap request and pass it to the listener
+	var recvMsg message
+	recvMsg, _, err := unmarshalMessage(buf)
+
+	if err == nil {
+		_, err = recvMsg.Pdu().Unmarshal(recvMsg.PduBytes())
+	}
+
+	s.Listener.OnTRAP(&TrapRequest{recvMsg, err})
+}
+
+func (s *Server) logf(format string, args ...interface{}) {
+	if s.ErrorLog != nil {
+		s.ErrorLog.Printf(format, args...)
+	} else {
+		log.Printf(format, args...)
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -35,7 +35,7 @@ func TestSendV2TrapAndReceiveIt(t *testing.T) {
 	trapSender.SendV2TrapWithBindings(varBinds)
 
 	trap := trapQueue.takeNextTrap()
-	pdu := trap.Message.Pdu()
+	pdu := trap.Pdu
 
 	if pdu.PduType() != snmpgo.SNMPTrapV2 {
 		t.Fatalf("expected trapv2, got: %s", pdu.PduType())

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,69 @@
+package snmpgo_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/k-sone/snmpgo"
+	"github.com/k-sone/snmpgo/snmptest"
+)
+
+type receiveQueue struct {
+	msg chan *snmpgo.TrapRequest
+}
+
+func (t *receiveQueue) OnTRAP(trap *snmpgo.TrapRequest) {
+	t.msg <- trap
+}
+
+// takeNextTrap blocks till next trap is received
+func (n *receiveQueue) takeNextTrap() *snmpgo.TrapRequest {
+	return <-n.msg
+}
+
+func TestSendV2TrapAndReceiveIt(t *testing.T) {
+	trapQueue := &receiveQueue{make(chan *snmpgo.TrapRequest)}
+	trapSender := snmptest.NewTrapSender(t)
+
+	s, _ := snmptest.NewServer("localhost:5000", trapQueue)
+	defer s.Close()
+
+	var varBinds snmpgo.VarBinds
+	oid, _ := snmpgo.NewOid("1.3.6.1.6.3.1.1.5.3")
+	varBinds = append(varBinds, snmpgo.NewVarBind(snmpgo.OidSnmpTrap, oid))
+
+	trapSender.SendV2TrapWithBindings(varBinds)
+
+	trap := trapQueue.takeNextTrap()
+	pdu := trap.Message.Pdu()
+
+	if pdu.PduType() != snmpgo.SNMPTrapV2 {
+		t.Fatalf("expected trapv2, got: %s", pdu.PduType())
+	}
+
+	if !reflect.DeepEqual(pdu.VarBinds(), varBinds) {
+		t.Fatalf("expected pdu bindings %v, got %v", varBinds, pdu.VarBinds())
+	}
+}
+
+func TestCollectMultipleTraps(t *testing.T) {
+	trapQueue := &receiveQueue{make(chan *snmpgo.TrapRequest)}
+	trapSender := snmptest.NewTrapSender(t)
+
+	s, _ := snmptest.NewServer("localhost:5000", trapQueue)
+	defer s.Close()
+
+	var varBinds snmpgo.VarBinds
+	oid, _ := snmpgo.NewOid("1.3.6.1.6.3.1.1.5.3")
+	varBinds = append(varBinds, snmpgo.NewVarBind(snmpgo.OidSnmpTrap, oid))
+
+	trapSender.SendV2TrapWithBindings(varBinds)
+	trapSender.SendV2TrapWithBindings(varBinds)
+	trapSender.SendV2TrapWithBindings(varBinds)
+
+	//TODO(mgenov): use deadline when checking such cases cause test deadline is really long
+	// will block forever if traps are not received
+	for i := 0; i < 3; i++ {
+		trapQueue.takeNextTrap()
+	}
+}

--- a/snmptest/sender.go
+++ b/snmptest/sender.go
@@ -1,0 +1,74 @@
+package snmptest
+
+import (
+	"net"
+	"testing"
+
+	"github.com/k-sone/snmpgo"
+)
+
+type TrapSender struct {
+	t       *testing.T
+	Address string
+}
+
+func NewTrapSender(t *testing.T) *TrapSender {
+	return &TrapSender{t: t, Address: "localhost:5000"}
+}
+
+func (t *TrapSender) SendV2TrapWithBindings(v snmpgo.VarBinds) {
+	snmp, err := snmpgo.NewSNMP(snmpgo.SNMPArguments{
+		Version:   snmpgo.V2c,
+		Address:   t.Address,
+		Network:   "udp4",
+		Retries:   1,
+		Community: "public",
+	})
+	if err != nil {
+		// Failed to create SNMP object
+		t.t.Fatal(err)
+		return
+	}
+
+	if err = snmp.Open(); err != nil {
+		// Failed to open connection
+		t.t.Fatal(err)
+		return
+	}
+
+	defer snmp.Close()
+
+	if err = snmp.V2Trap(v); err != nil {
+		// Failed to request
+		t.t.Fatal(err)
+		return
+	}
+
+}
+
+// Server is a testing Trap server
+type Server struct {
+	l net.Conn
+	*snmpgo.Server
+}
+
+// NewServer creates a new Trap Server
+func NewServer(address string, listener snmpgo.TrapListener) (*Server, error) {
+	s := &snmpgo.Server{}
+	addr, err := net.ResolveUDPAddr("udp4", address)
+	if err != nil {
+		return nil, err
+	}
+
+	l, err := net.ListenUDP("udp4", addr)
+	if err != nil {
+		return nil, err
+	}
+	go s.Serve(l, listener)
+
+	return &Server{l, s}, nil
+}
+
+func (s *Server) Close() {
+	s.l.Close()
+}


### PR DESCRIPTION
This change adds trap server which is responsible for receiving of trap events. When server receives trap package it will be decoded and dispatched to concrete listener using separate goroutine.

Fixes #3 

I would like to get feedback about this change, before adding of docs and examples. 