### PR TITLE
Fix for data race in generating request ids

### DIFF
--- a/util.go
+++ b/util.go
@@ -21,9 +21,13 @@ func initRandom() {
 	random = rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
+var reqMutex sync.Mutex
 func genRequestId() int {
 	randOnce.Do(initRandom)
-	return int(random.Int31())
+	reqMutex.Lock()
+	val := int(random.Int31())
+	reqMutex.Unlock()
+	return val
 }
 
 func genSalt32() int32 {


### PR DESCRIPTION
This fixes a bug where calling random.Int31() from multiple go routines generates a race condition.

The problem is:

==================
WARNING: DATA RACE
Read at 0x00c420027460 by goroutine 281:
  math/rand.(*rngSource).Int63()
      /usr/local/Cellar/go/1.7.3/libexec/src/math/rand/rng.go:243 +0x156
  math/rand.(*Rand).Int63()
      /usr/local/Cellar/go/1.7.3/libexec/src/math/rand/rand.go:64 +0x51
  math/rand.(*Rand).Int31()
      /usr/local/Cellar/go/1.7.3/libexec/src/math/rand/rand.go:70 +0x38
  github.com/k-sone/snmpgo.genRequestId()
      /Users/whoami/Desktop/code/golang/src/github.com/k-sone/snmpgo/util.go:26 +0x66
  github.com/k-sone/snmpgo.(*messageProcessingV1).PrepareOutgoingMessage()
      /Users/whoami/Desktop/code/golang/src/github.com/k-sone/snmpgo/mprocessing.go:33 +0x87
  github.com/k-sone/snmpgo.(*snmpEngine).SendPdu()
      /Users/whoami/Desktop/code/golang/src/github.com/k-sone/snmpgo/engine.go:21 +0xfe
  github.com/k-sone/snmpgo.(*SNMP).sendPdu.func1()
      /Users/whoami/Desktop/code/golang/src/github.com/k-sone/snmpgo/client.go:320 +0xf2
  github.com/k-sone/snmpgo.retry()
      /Users/whoami/Desktop/code/golang/src/github.com/k-sone/snmpgo/util.go:56 +0x6d
  github.com/k-sone/snmpgo.(*SNMP).sendPdu()
      /Users/whoami/Desktop/code/golang/src/github.com/k-sone/snmpgo/client.go:322 +0x19d
  github.com/k-sone/snmpgo.(*SNMP).GetRequest()
      /Users/whoami/Desktop/code/golang/src/github.com/k-sone/snmpgo/client.go:162 +0xb3
...

Previous write at 0x00c420027460 by goroutine 13:
  math/rand.(*rngSource).Int63()
      /usr/local/Cellar/go/1.7.3/libexec/src/math/rand/rng.go:244 +0x1be
  math/rand.(*Rand).Int63()
      /usr/local/Cellar/go/1.7.3/libexec/src/math/rand/rand.go:64 +0x51
  math/rand.(*Rand).Int31()
      /usr/local/Cellar/go/1.7.3/libexec/src/math/rand/rand.go:70 +0x38
  github.com/k-sone/snmpgo.genRequestId()
      /Users/whoami/Desktop/code/golang/src/github.com/k-sone/snmpgo/util.go:26 +0x66
  github.com/k-sone/snmpgo.(*messageProcessingV1).PrepareOutgoingMessage()
      /Users/whoami/Desktop/code/golang/src/github.com/k-sone/snmpgo/mprocessing.go:33 +0x87
  github.com/k-sone/snmpgo.(*snmpEngine).SendPdu()
      /Users/whoami/Desktop/code/golang/src/github.com/k-sone/snmpgo/engine.go:21 +0xfe
  github.com/k-sone/snmpgo.(*SNMP).sendPdu.func1()
      /Users/whoami/Desktop/code/golang/src/github.com/k-sone/snmpgo/client.go:320 +0xf2
  github.com/k-sone/snmpgo.retry()
      /Users/whoami/Desktop/code/golang/src/github.com/k-sone/snmpgo/util.go:56 +0x6d
  github.com/k-sone/snmpgo.(*SNMP).sendPdu()
      /Users/whoami/Desktop/code/golang/src/github.com/k-sone/snmpgo/client.go:322 +0x19d
  github.com/k-sone/snmpgo.(*SNMP).GetRequest()
      /Users/whoami/Desktop/code/golang/src/github.com/k-sone/snmpgo/client.go:162 +0xb3
....

Goroutine 281 (running) created at:
...

Goroutine 13 (running) created at:
...

It is generated by do something similar to the following:

  for ip := network.CIDR.IP.Mask(network.CIDR.Net.Mask);
            network.CIDR.Net.Contains(ip);
            IncrementIP(ip) {
    go func(dupip net.IP) {
      QuerySNMP(ip)
    }(ip)
  }

Putting a mutex around calls to rand.Int31() solves this issue.