### PR TITLE
fix OctetString.String() to return human-readable string

### DIFF
--- a/variables.go
+++ b/variables.go
@@ -60,7 +60,12 @@ func (v *OctetString) BigInt() (*big.Int, error) {
 
 func (v *OctetString) String() string {
 	for _, c := range v.Value {
-		if !strconv.IsPrint(rune(c)) {
+		switch {
+		case c >= 0x20 && c <= 0x7e:
+			// printable character including space
+		case c >= 0x09 && c <= 0x0d:
+			// '\t', '\n', '\v', '\f', '\r'
+		default:
 			return toHexStr(v.Value, ":")
 		}
 	}

--- a/variables_test.go
+++ b/variables_test.go
@@ -97,6 +97,33 @@ func TestOctetString(t *testing.T) {
 	}
 }
 
+func TestOctetString2(t *testing.T) {
+	expStr := "\t\n\v\f\r !\"#$%&'()*+,-./0123456789:;<=>?@ABCXYZ[\\]^_`abcxyz{|}~"
+	var v snmpgo.Variable = snmpgo.NewOctetString([]byte(expStr))
+
+	if expStr != v.String() {
+		t.Errorf("String() human-readable - expected [%s], actual[%s]", expStr, v.String())
+	}
+
+	expStr = "c0:a8:01:01"
+	v = snmpgo.NewOctetString([]byte{192, 168, 1, 1})
+	if expStr != v.String() {
+		t.Errorf("String() hex-string - expected [%s], actual[%s]", expStr, v.String())
+	}
+
+	expStr = "54:65:73:74:08"
+	v = snmpgo.NewOctetString([]byte{0x54, 0x65, 0x73, 0x74, 0x08})
+	if expStr != v.String() {
+		t.Errorf("String() hex-string - expected [%s], actual[%s]", expStr, v.String())
+	}
+
+	expStr = "54:65:73:74:a0"
+	v = snmpgo.NewOctetString([]byte{0x54, 0x65, 0x73, 0x74, 0xa0})
+	if expStr != v.String() {
+		t.Errorf("String() hex-string - expected [%s], actual[%s]", expStr, v.String())
+	}
+}
+
 func TestNull(t *testing.T) {
 	expStr := ""
 	expBuf := []byte{0x05, 0x00}


### PR DESCRIPTION
When OctetString contains characters from 0x80 to 0xff, String() returns non-human-readable string.
And contains white-space characters other than 0x20, String() returns a hex string.

`isprint(3)` or `isspace(3)` is true, OctetString is converted to a string as it is.
Otherwise, convert it to a hex string.