### PR TITLE
Defining a StdLogger interface to allow setting of any logger

### DIFF
--- a/log.go
+++ b/log.go
@@ -3,13 +3,4 @@ package snmpgo
 type StdLogger interface {
 	Print(v ...interface{})
 	Printf(format string, v ...interface{})
-	Println(v ...interface{})
-
-	Fatal(v ...interface{})
-	Fatalf(format string, v ...interface{})
-	Fatalln(v ...interface{})
-
-	Panic(v ...interface{})
-	Panicf(format string, v ...interface{})
-	Panicln(v ...interface{})
 }

--- a/log.go
+++ b/log.go
@@ -1,0 +1,15 @@
+package snmpgo
+
+type StdLogger interface {
+	Print(v ...interface{})
+	Printf(format string, v ...interface{})
+	Println(v ...interface{})
+
+	Fatal(v ...interface{})
+	Fatalf(format string, v ...interface{})
+	Fatalln(v ...interface{})
+
+	Panic(v ...interface{})
+	Panicf(format string, v ...interface{})
+	Panicln(v ...interface{})
+}

--- a/server.go
+++ b/server.go
@@ -40,7 +40,7 @@ func (a *ServerArguments) validate() error {
 	default:
 		return &ArgumentError{
 			Value:   a.Network,
-			Message: fmt.Sprintf("Unsupported Network", a.Network),
+			Message: fmt.Sprintf("Unsupported Network: %s", a.Network),
 		}
 	}
 	if m := a.MessageMaxSize; (m != 0 && m < msgSizeMinimum) || m > math.MaxInt32 {
@@ -164,7 +164,7 @@ type TrapServer struct {
 	serving   bool
 
 	// Error Logger which will be used for logging of default errors
-	ErrorLog *log.Logger
+	ErrorLog StdLogger
 }
 
 func (s *TrapServer) AddSecurity(entry *SecurityEntry) error {


### PR DESCRIPTION
We have a use-case where we'd like to be able to specify a custom logger for `TrapServer` to write to in the event of an error that is not an instance of the built-in `log.Logger` struct.

There was also a missing `%s` on line 43 in [server.go](https://github.com/myENA/snmpgo/blob/feature/logger-interface/server.go#L43), not sure if the syntax is OK for you but I've added it anyway.

Comments welcome.