### PR TITLE
Error message correction 

### DIFF
--- a/util.go
+++ b/util.go
@@ -94,7 +94,7 @@ func engineIdToBytes(engineId string) ([]byte, error) {
 	if l := len(b); err != nil || (l < 5 || l > 32) {
 		return nil, &ArgumentError{
 			Value:   engineId,
-			Message: "EngineId must be a hexadecimal string and length is range 5..32",
+			Message: "EngineId must be a hexadecimal string and length is range 10..64",
 		}
 	}
 	return b, nil


### PR DESCRIPTION
There is a mistake in the error message. The first part of error message is referring to hexadecimal string while the second part after "and" which specifies the length is referring to bytes. The length of the engineID in hexadecimal provided by the user must be 10..64 characters.